### PR TITLE
Document MJPEG live camera config in hardware.yaml

### DIFF
--- a/config/hardware.yaml
+++ b/config/hardware.yaml
@@ -1,4 +1,11 @@
 camera:
+  # Live mode (IP Webcam app on Android):
+  #   type: "mjpeg"
+  #   uri: "http://192.168.1.x:8080/video"
+  #   reconnect_delay_ms: 2000
+  #   max_reconnect_attempts: 10
+  #   grab_timeout_ms: 5000
+  # USB camera (future): type: "usb", uri: "0"
   type: "file"
   uri: "video_replays/fennekin_normal/images"
 


### PR DESCRIPTION
## Summary

- Added commented MJPEG example block to `config/hardware.yaml` with all reconnect fields (`reconnect_delay_ms`, `max_reconnect_attempts`, `grab_timeout_ms`)
- Added note for future USB camera path (`type: "usb", uri: "0"`)
- Default `type: "file"` unchanged — all existing tests still pass

Closes #8