### PR TITLE
Add --record flag to capture live stream frames to video file

### DIFF
--- a/src/App/DebugLayer.cpp
+++ b/src/App/DebugLayer.cpp
@@ -21,7 +21,8 @@ namespace SH3DS::App
         std::string shinyRoi,
         std::string shinyCheckState,
         size_t totalFrames,
-        float targetFps)
+        float targetFps,
+        std::string recordPath)
         : source(std::move(source)),
           seeker(seeker),
           screenDetector(std::move(screenDetector)),
@@ -31,7 +32,8 @@ namespace SH3DS::App
           shinyRoi(std::move(shinyRoi)),
           shinyCheckState(std::move(shinyCheckState)),
           playback(totalFrames, targetFps),
-          isLiveSource(seeker == nullptr)
+          isLiveSource(seeker == nullptr),
+          recordPath(std::move(recordPath))
     {
         // Initialize ImGui
         IMGUI_CHECKVERSION();
@@ -66,6 +68,12 @@ namespace SH3DS::App
 
     DebugLayer::~DebugLayer()
     {
+        if (isRecording)
+        {
+            videoWriter.release();
+            LOG_INFO("Recording saved to {}", recordPath);
+        }
+
         // Stop capture thread before tearing down OpenGL/ImGui
         if (captureRunning)
         {
@@ -183,6 +191,30 @@ namespace SH3DS::App
         currentRawFrame = frame.image.clone();
         rawWidth = currentRawFrame.cols;
         rawHeight = currentRawFrame.rows;
+
+        // Lazy-init recorder on first live frame
+        if (!recordPath.empty() && isLiveSource && !isRecording)
+        {
+            videoWriter.open(recordPath,
+                cv::VideoWriter::fourcc('M', 'J', 'P', 'G'),
+                static_cast<double>(playback.GetTargetFps()),
+                cv::Size(rawWidth, rawHeight));
+            if (videoWriter.isOpened())
+            {
+                isRecording = true;
+                LOG_INFO("Recording live stream to {}", recordPath);
+            }
+            else
+            {
+                LOG_ERROR("Failed to open VideoWriter at {}", recordPath);
+                recordPath.clear(); // don't retry
+            }
+        }
+
+        if (isRecording)
+        {
+            videoWriter.write(currentRawFrame);
+        }
 
         TextureUploader::Upload(currentRawFrame, rawFrameTexture);
 

--- a/src/App/DebugLayer.h
+++ b/src/App/DebugLayer.h
@@ -11,6 +11,8 @@
 #include "PlaybackController.h"
 #include "Vision/ShinyDetector.h"
 
+#include <opencv2/videoio.hpp>
+
 #include <atomic>
 #include <chrono>
 #include <memory>
@@ -45,6 +47,7 @@ namespace SH3DS::App
          * @param shinyCheckState FSM state in which shiny detection runs.
          * @param totalFrames Total number of frames in replay source (0 for live).
          * @param targetFps Target playback FPS.
+         * @param recordPath Output path for recording live frames (e.g. "rec.avi"). Empty = no recording.
          */
         DebugLayer(GLFWwindow *window,
             std::unique_ptr<Capture::FrameSource> source,
@@ -56,7 +59,8 @@ namespace SH3DS::App
             std::string shinyRoi,
             std::string shinyCheckState,
             size_t totalFrames,
-            float targetFps);
+            float targetFps,
+            std::string recordPath = "");
 
         ~DebugLayer() override;
 
@@ -142,6 +146,11 @@ namespace SH3DS::App
         float timeInState = 0.0f;                            ///< Time in current state (seconds)
         std::optional<Core::ShinyResult> currentShinyResult; ///< Latest shiny detection result
         size_t lastProcessedFrame = SIZE_MAX;                ///< Last processed frame index (replay only)
+
+        // Recording (live mode only)
+        std::string recordPath;      ///< Output file path; empty = no recording
+        cv::VideoWriter videoWriter; ///< Writes raw frames to file
+        bool isRecording = false;    ///< True once VideoWriter is open
 
         // Frame dimensions (for display)
         int rawWidth = 0;                             ///< Raw frame width

--- a/src/App/SH3DSDebugApp.cpp
+++ b/src/App/SH3DSDebugApp.cpp
@@ -17,7 +17,8 @@ namespace SH3DS::App
 {
     SH3DSDebugApp::SH3DSDebugApp(const std::string &hardwareConfigPath,
         const std::string &huntConfigPath,
-        const std::string &replaySourcePath)
+        const std::string &replaySourcePath,
+        const std::string &recordPath)
         : Application(GetSpec())
     {
         auto pipeline = BuildPipeline(hardwareConfigPath, huntConfigPath, replaySourcePath);
@@ -37,7 +38,8 @@ namespace SH3DS::App
             pipeline.shinyRoi,
             pipeline.shinyCheckState,
             pipeline.totalFrames,
-            pipeline.targetFps);
+            pipeline.targetFps,
+            recordPath);
     }
 
     SH3DSDebugApp::PipelineComponents SH3DSDebugApp::BuildPipeline(const std::string &hardwareConfigPath,

--- a/src/App/SH3DSDebugApp.h
+++ b/src/App/SH3DSDebugApp.h
@@ -27,7 +27,8 @@ namespace SH3DS::App
          */
         SH3DSDebugApp(const std::string &hardwareConfigPath,
             const std::string &huntConfigPath,
-            const std::string &replaySourcePath);
+            const std::string &replaySourcePath,
+            const std::string &recordPath = "");
 
     private:
         /**

--- a/src/Sh3DSApp/Sh3DSAppGUI.cpp
+++ b/src/Sh3DSApp/Sh3DSAppGUI.cpp
@@ -18,16 +18,18 @@ int main(int argc, char *argv[])
     std::string hardwareConfigPath = "config/hardware.yaml";
     std::string huntConfigPath = "config/hunts/xy_starter_sr_fennekin.yaml";
     std::string replayPath;
+    std::string recordPath;
 
     app.add_option("--hardware", hardwareConfigPath, "Path to hardware config YAML");
     app.add_option("--hunt-config", huntConfigPath, "Path to unified hunt config YAML");
     app.add_option("--replay", replayPath, "Replay source (directory or video file)");
+    app.add_option("--record", recordPath, "Record live stream to a video file (e.g. rec.avi)");
 
     CLI11_PARSE(app, argc, argv);
 
     try
     {
-        SH3DS::App::SH3DSDebugApp debugApp(hardwareConfigPath, huntConfigPath, replayPath);
+        SH3DS::App::SH3DSDebugApp debugApp(hardwareConfigPath, huntConfigPath, replayPath, recordPath);
         debugApp.Run();
     }
     catch (const std::exception &e)


### PR DESCRIPTION
## Summary

- New `--record <path.avi>` CLI flag records raw frames from live stream to a MJPEG video file
- Recording is lazy-init on first frame (frame size unknown before first Grab)
- Recorded file can be replayed via `--replay` for offline FSM analysis and tuning
- No-op in replay mode and when flag is omitted

## Usage

```bash
# Record live session
./sh3ds --hardware config/hardware.yaml --hunt-config config/hunts/xy_starter_sr_fennekin.yaml --record debug_session.avi

# Replay the recording for analysis
./sh3ds --hardware config/hardware.yaml --hunt-config config/hunts/xy_starter_sr_fennekin.yaml --replay debug_session.avi
```

## Test plan

- [x] All 173 tests pass (no regressions)