### PR TITLE
Add resetting FSM state to fix premature load_game -> game_start transition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ scripts/
 logs/
 *.log
 
+# ImGui layout state
+imgui_*.ini
+
 # OS
 .DS_Store
 Thumbs.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@
 - `--replay` CLI flag is now optional; omitting it activates live camera mode
 - Camera factory dispatch in `BuildPipeline`: `mjpeg` → `MjpegFrameSource`, replay path → `FileFrameSource`/`VideoFrameSource`
 - MJPEG config example documented in `config/hardware.yaml`
+- `resetting` FSM state between `pokemon_summary` and `load_game` to fix premature `load_game → game_start` transition on soft reset
+- `analyze_frames.py` tool for frame-level pipeline inspection
+- Integration test `XYStarterFennekinLive` for real camera footage (skipped when frames absent)
+
+### Fixed
+
+- Mutex UB in `MjpegFrameSource::TryReconnect` — `lock_guard` + raw `mutex.unlock()`/`lock()` caused double-unlock (UB); replaced with `unique_lock` passed by reference
+- `MjpegFrameSource::Open()` now calls `capture.release()` before reopening, making it safe to call without an intervening `Close()`
+- `DebugLayer` destructor now joins capture thread before releasing `videoWriter`
+- Capture thread now exits cleanly when frame source is permanently closed (exhausted reconnects)
+- `TestHuntProfiles` fixture was missing `"resetting"` state — `CreateXYStarterSRSucceedsWithCompleteParams` was incorrectly throwing
+- Unnecessary `cv::Mat::clone()` in `DebugLayer::ProcessFrame` replaced with refcounted shallow copy (O(1))
 
 ## [0.1.0] - 2026-03-09
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -125,6 +125,13 @@
             }
         },
         {
+            "name": "ninja-release",
+            "configurePreset": "ninja-release",
+            "output": {
+                "outputOnFailure": true
+            }
+        },
+        {
             "name": "visual-studio-debug",
             "configurePreset": "visual-studio",
             "configuration": "Debug",

--- a/config/hardware.yaml
+++ b/config/hardware.yaml
@@ -5,9 +5,14 @@ camera:
   #   reconnect_delay_ms: 2000
   #   max_reconnect_attempts: 10
   #   grab_timeout_ms: 5000
+  #   rotation_degrees: 0   # 0 / 90 / 180 / 270 clockwise
   # USB camera (future): type: "usb", uri: "0"
-  type: "file"
-  uri: "video_replays/fennekin_normal/images"
+  type: "mjpeg"
+  uri: "http://192.168.0.111:8080/video"
+  reconnect_delay_ms: 2000
+  max_reconnect_attempts: 5
+  grab_timeout_ms: 5000
+  rotation_degrees: 90
 
 console:
   type: "luma3ds"

--- a/config/hunts/xy_starter_sr_fennekin.yaml
+++ b/config/hunts/xy_starter_sr_fennekin.yaml
@@ -49,7 +49,15 @@ fsm_states:
   load_game:
     top:
       roi: "top_full"
-      method: "intensity_event"
+      method: "always_true"
+      threshold: 0.5
+    bottom:
+      roi: "top_full"
+      method: "color_histogram"
+      hsv_lower: [0, 0, 180]
+      hsv_upper: [179, 60, 255]
+      pixel_ratio_min: 0.4
+      pixel_ratio_max: 1.0
       threshold: 0.5
 
   game_start:
@@ -104,6 +112,16 @@ fsm_states:
     bottom:
       roi: "top_full"
       method: "always_true"
+      threshold: 0.5
+
+  resetting:
+    top:
+      roi: "top_full"
+      method: "color_histogram"
+      hsv_lower: [0, 0, 0]
+      hsv_upper: [179, 255, 50]
+      pixel_ratio_min: 0.3
+      pixel_ratio_max: 1.0
       threshold: 0.5
 
 # Shiny detector (dominant color method)

--- a/src/App/DebugLayer.cpp
+++ b/src/App/DebugLayer.cpp
@@ -68,13 +68,7 @@ namespace SH3DS::App
 
     DebugLayer::~DebugLayer()
     {
-        if (isRecording)
-        {
-            videoWriter.release();
-            LOG_INFO("Recording saved to {}", recordPath);
-        }
-
-        // Stop capture thread before tearing down OpenGL/ImGui
+        // Stop capture thread first — ProcessFrame must not run after we release resources
         if (captureRunning)
         {
             captureRunning = false;
@@ -82,6 +76,12 @@ namespace SH3DS::App
             {
                 captureThread.join();
             }
+        }
+
+        if (isRecording)
+        {
+            videoWriter.release();
+            LOG_INFO("Recording saved to {}", recordPath);
         }
 
         ImGui_ImplOpenGL3_Shutdown();
@@ -188,7 +188,7 @@ namespace SH3DS::App
 
     void DebugLayer::ProcessFrame(const Core::Frame &frame)
     {
-        currentRawFrame = frame.image.clone();
+        currentRawFrame = frame.image; // shallow refcounted copy — O(1), data lifetime managed by refcount
         rawWidth = currentRawFrame.cols;
         rawHeight = currentRawFrame.rows;
 

--- a/src/App/DebugLayer.cpp
+++ b/src/App/DebugLayer.cpp
@@ -319,9 +319,16 @@ namespace SH3DS::App
                     }
                     ++totalFramesGrabbed;
                 }
+                else if (!source->IsOpen())
+                {
+                    // Source permanently closed (exhausted reconnects) — exit capture thread
+                    LOG_WARN("DebugLayer: frame source closed, stopping capture thread");
+                    captureRunning = false;
+                    break;
+                }
                 else
                 {
-                    // Avoid busy-spin on error / stream end
+                    // Transient failure — avoid busy-spin
                     std::this_thread::sleep_for(std::chrono::milliseconds(10));
                 }
             }

--- a/src/App/DebugLayer.h
+++ b/src/App/DebugLayer.h
@@ -118,11 +118,12 @@ namespace SH3DS::App
         PlaybackController playback; ///< Playback state controller
 
         // Live mode
-        bool isLiveSource = false;                         ///< True when seeker == nullptr (live camera)
-        std::thread captureThread;                         ///< Background capture thread (live only)
-        std::atomic<bool> captureRunning{ false };         ///< Signals capture thread to stop
-        std::mutex latestFrameMutex;                       ///< Guards latestFrame
-        std::optional<Core::Frame> latestFrame;            ///< Latest frame from capture thread
+        bool isLiveSource = false;                 ///< True when seeker == nullptr (live camera)
+        std::thread captureThread;                 ///< Background capture thread (live only)
+        std::atomic<bool> captureRunning{ false }; ///< Signals capture thread to stop
+        std::mutex latestFrameMutex;               ///< Guards latestFrame
+        std::optional<Core::Frame> latestFrame;    ///< Latest frame from capture thread; single-slot — older frames are
+                                                   ///< dropped if render thread hasn't consumed them yet
         std::atomic<size_t> totalFramesGrabbed{ 0 };       ///< Monotonically increasing grab counter
         float liveGrabFps = 0.0f;                          ///< Estimated grab FPS (render thread)
         std::chrono::steady_clock::time_point lastFpsTime; ///< Timestamp for FPS estimation

--- a/src/Capture/MjpegFrameSource.cpp
+++ b/src/Capture/MjpegFrameSource.cpp
@@ -19,6 +19,7 @@ namespace SH3DS::Capture
     {
         std::lock_guard<std::mutex> lock(mutex);
 
+        capture.release();
         permanentlyFailed = false;
         currentReconnectAttempts = 0;
         frameCounter = 0;

--- a/src/Capture/MjpegFrameSource.cpp
+++ b/src/Capture/MjpegFrameSource.cpp
@@ -51,7 +51,7 @@ namespace SH3DS::Capture
 
     std::optional<Core::Frame> MjpegFrameSource::Grab()
     {
-        std::lock_guard<std::mutex> lock(mutex);
+        std::unique_lock<std::mutex> lock(mutex);
 
         if (!isOpen || permanentlyFailed)
         {
@@ -62,8 +62,12 @@ namespace SH3DS::Capture
         if (!capture.read(image) || image.empty())
         {
             LOG_WARN("MjpegFrameSource: Read failed, attempting reconnect...");
-            // mutex is already held — TryReconnect must not re-lock
-            if (!TryReconnect())
+            if (!TryReconnect(lock))
+            {
+                return std::nullopt;
+            }
+            // Re-check state: Close() may have run during the reconnect sleep
+            if (!isOpen || permanentlyFailed)
             {
                 return std::nullopt;
             }
@@ -95,9 +99,9 @@ namespace SH3DS::Capture
         return "MjpegFrameSource(" + uri + ")";
     }
 
-    bool MjpegFrameSource::TryReconnect()
+    bool MjpegFrameSource::TryReconnect(std::unique_lock<std::mutex> &lock)
     {
-        // Called with mutex already held.
+        // Called with lock already held.
         for (int attempt = 1; attempt <= maxReconnectAttempts; ++attempt)
         {
             currentReconnectAttempts = attempt;
@@ -107,12 +111,16 @@ namespace SH3DS::Capture
 
             if (reconnectDelayMs > 0)
             {
-                // Temporarily release the mutex while sleeping to avoid blocking other threads.
-                // We re-check state after re-acquiring — but since we are the only producer this
-                // is safe for the single-slot live capture pattern.
-                mutex.unlock();
+                // Temporarily release the lock while sleeping so Close() / IsOpen() are not blocked.
+                // Re-check state after reacquire — Close() may have run during the sleep.
+                lock.unlock();
                 std::this_thread::sleep_for(std::chrono::milliseconds(reconnectDelayMs));
-                mutex.lock();
+                lock.lock();
+
+                if (!isOpen || permanentlyFailed)
+                {
+                    return false;
+                }
             }
 
             capture.set(cv::CAP_PROP_OPEN_TIMEOUT_MSEC, static_cast<double>(grabTimeoutMs));

--- a/src/Capture/MjpegFrameSource.h
+++ b/src/Capture/MjpegFrameSource.h
@@ -1,8 +1,7 @@
 #pragma once
 
-#include "FrameSource.h"
-
 #include "Core/Config.h"
+#include "FrameSource.h"
 
 #include <opencv2/videoio.hpp>
 
@@ -49,16 +48,16 @@ namespace SH3DS::Capture
          */
         bool TryReconnect();
 
-        std::string uri;                ///< Stream URI (HTTP URL or local file path)
-        int reconnectDelayMs;           ///< Delay between reconnect attempts in ms
-        int maxReconnectAttempts;       ///< Maximum number of reconnect attempts
-        int grabTimeoutMs;              ///< Open/read timeout in ms (passed to VideoCapture)
-        cv::VideoCapture capture;       ///< OpenCV capture object
-        mutable std::mutex mutex;       ///< Guards capture and frame counter
-        size_t frameCounter = 0;        ///< Monotonically increasing sequence number
+        std::string uri;                  ///< Stream URI (HTTP URL or local file path)
+        int reconnectDelayMs;             ///< Delay between reconnect attempts in ms
+        int maxReconnectAttempts;         ///< Maximum number of reconnect attempts
+        int grabTimeoutMs;                ///< Open/read timeout in ms (passed to VideoCapture)
+        cv::VideoCapture capture;         ///< OpenCV capture object
+        mutable std::mutex mutex;         ///< Guards capture and frame counter
+        size_t frameCounter = 0;          ///< Monotonically increasing sequence number
         int currentReconnectAttempts = 0; ///< Reconnect attempts used in last failure run
-        bool isOpen = false;            ///< Whether capture is currently open
-        bool permanentlyFailed = false; ///< True after exhausting all reconnect attempts
+        bool isOpen = false;              ///< Whether capture is currently open
+        bool permanentlyFailed = false;   ///< True after exhausting all reconnect attempts
     };
 
 } // namespace SH3DS::Capture

--- a/src/Capture/MjpegFrameSource.h
+++ b/src/Capture/MjpegFrameSource.h
@@ -44,9 +44,10 @@ namespace SH3DS::Capture
     private:
         /**
          * @brief Attempts to reconnect up to maxReconnectAttempts times.
+         * @param lock The unique_lock already held by the caller (may be temporarily released during sleep).
          * @return True if reconnection succeeded.
          */
-        bool TryReconnect();
+        bool TryReconnect(std::unique_lock<std::mutex> &lock);
 
         std::string uri;                  ///< Stream URI (HTTP URL or local file path)
         int reconnectDelayMs;             ///< Delay between reconnect attempts in ms

--- a/src/FSM/CXXStateTreeFSM.cpp
+++ b/src/FSM/CXXStateTreeFSM.cpp
@@ -148,6 +148,8 @@ namespace SH3DS::FSM
         pendingFrameCount = 0;
         raisesAtLastTransition = topIntensityDetector.GetEvents().size();
 
+        LOG_INFO(
+            "FSM transition: {} -> {} at intensity frame {}", transition.from, transition.to, intensityFrameCounter);
         RecordTransition(transition);
 
         return transition;
@@ -453,7 +455,7 @@ namespace SH3DS::FSM
                 continue;
             }
             const double avgV = ComputeAverageV(it->second);
-            LOG_DEBUG("IntensityDetector advance: avgV={:.3f} frame={}", avgV, intensityFrameCounter);
+            LOG_INFO("IntensityDetector advance: avgV={:.3f} frame={}", avgV, intensityFrameCounter);
             topIntensityDetector.Update(avgV, intensityFrameCounter++);
             return;
         }

--- a/src/FSM/CXXStateTreeFSM.cpp
+++ b/src/FSM/CXXStateTreeFSM.cpp
@@ -455,7 +455,7 @@ namespace SH3DS::FSM
                 continue;
             }
             const double avgV = ComputeAverageV(it->second);
-            LOG_INFO("IntensityDetector advance: avgV={:.3f} frame={}", avgV, intensityFrameCounter);
+            LOG_DEBUG("IntensityDetector advance: avgV={:.3f} frame={}", avgV, intensityFrameCounter);
             topIntensityDetector.Update(avgV, intensityFrameCounter++);
             return;
         }

--- a/src/FSM/HuntProfiles.cpp
+++ b/src/FSM/HuntProfiles.cpp
@@ -77,10 +77,17 @@ namespace SH3DS::FSM
 
         builder.AddState({
             .id = "pokemon_summary",
-            .transitionsTo = { "load_game" },
+            .transitionsTo = { "resetting" },
             .maxDurationS = 20,
             .shinyCheck = true,
             .detectionParameters = RequireState(params, "pokemon_summary"),
+        });
+
+        builder.AddState({
+            .id = "resetting",
+            .transitionsTo = { "load_game" },
+            .maxDurationS = 30,
+            .detectionParameters = RequireState(params, "resetting"),
         });
 
         return builder.Build();

--- a/src/Vision/IntensityEventDetector.h
+++ b/src/Vision/IntensityEventDetector.h
@@ -28,7 +28,7 @@ namespace SH3DS::Vision
      */
     struct IntensityEventConfig
     {
-        double dropThreshold = 0.40;  ///< V < dropThreshold  * vMax  -> DROP
+        double dropThreshold = 0.30;  ///< V < dropThreshold  * vMax  -> DROP
         double raiseThreshold = 0.50; ///< V > raiseThreshold * vMax  -> RAISE
         double vMaxDecay =
             0.9995; ///< Per-frame exponential decay of the baseline (initialised to 0 — ramps up from first frame)

--- a/tests/integration/TestXYStarterFennekinReplay.cpp
+++ b/tests/integration/TestXYStarterFennekinReplay.cpp
@@ -11,6 +11,62 @@
 #include <string>
 #include <vector>
 
+namespace
+{
+    /// Shared pipeline runner — same logic as Orchestrator::MainLoopTick.
+    /// Returns a per-frame state log (0-based indices).
+    std::vector<std::string> RunPipeline(const std::filesystem::path &imagesPath,
+        const std::filesystem::path &huntCfgPath)
+    {
+        auto unified = SH3DS::Core::LoadUnifiedHuntConfig(huntCfgPath.string());
+
+        auto frameSource = SH3DS::Capture::FileFrameSource::CreateFileFrameSource(imagesPath, 0.0);
+        if (!frameSource || !frameSource->Open())
+        {
+            return {};
+        }
+
+        auto screenDetector = SH3DS::Capture::ScreenDetector::CreateScreenDetector();
+        SH3DS::Core::ScreenCalibrationConfig topCalib;
+        SH3DS::Capture::FramePreprocessor preprocessor(topCalib, unified.rois, std::nullopt);
+        auto fsm = SH3DS::FSM::HuntProfiles::CreateXYStarterSR(unified.fsmParams);
+
+        std::vector<std::string> stateLog;
+        std::string lastState = fsm->GetCurrentState();
+
+        while (true)
+        {
+            auto frame = frameSource->Grab();
+            if (!frame.has_value())
+            {
+                break;
+            }
+
+            screenDetector->ApplyTo(preprocessor, frame->image);
+
+            auto dualResult = preprocessor.ProcessDualScreen(frame->image);
+            if (!dualResult.has_value())
+            {
+                stateLog.push_back(lastState);
+                continue;
+            }
+
+            if (!dualResult->warpedTop.empty())
+            {
+                dualResult->warpedTop = SH3DS::Vision::ImproveFrameColors(dualResult->warpedTop);
+                preprocessor.ReextractRois(*dualResult);
+            }
+
+            fsm->Update(dualResult->topRois, dualResult->bottomRois);
+            lastState = fsm->GetCurrentState();
+            stateLog.push_back(lastState);
+        }
+
+        frameSource->Close();
+        return stateLog;
+    }
+} // namespace
+
 /// Integration test: runs the real pipeline against the Fennekin video replay
 /// and asserts the FSM reaches expected states at safe midpoint frames.
 ///
@@ -20,71 +76,14 @@ TEST(XYStarterFennekinReplay, StateSequenceMatchesExpected)
 {
     const std::filesystem::path kRepo = SH3DS_REPO_ROOT;
     const auto imagesPath = kRepo / "video_replays/fennekin_normal/images";
-    const auto huntCfgPath = (kRepo / "config/hunts/xy_starter_sr_fennekin.yaml").string();
+    const auto huntCfgPath = kRepo / "config/hunts/xy_starter_sr_fennekin.yaml";
 
-    // Skip test gracefully if replay frames are not present
     if (!std::filesystem::exists(imagesPath) || std::filesystem::is_empty(imagesPath))
     {
         GTEST_SKIP() << "Replay frames not found at " << imagesPath << " — skipping video replay test.";
     }
 
-    // 1. Load config from YAML
-    auto unified = SH3DS::Core::LoadUnifiedHuntConfig(huntCfgPath);
-
-    // 2. Frame source
-    auto frameSource = SH3DS::Capture::FileFrameSource::CreateFileFrameSource(imagesPath, 0.0);
-    ASSERT_NE(frameSource, nullptr);
-    ASSERT_TRUE(frameSource->Open()) << "Failed to open frame source at " << imagesPath;
-
-    // 3. Screen detector (auto-calibrates from first ~15 frames)
-    auto screenDetector = SH3DS::Capture::ScreenDetector::CreateScreenDetector();
-
-    // 4. Frame preprocessor — zeroed top corners (ScreenDetector populates them at runtime)
-    SH3DS::Core::ScreenCalibrationConfig topCalib; // corners default to all-zero
-    SH3DS::Capture::FramePreprocessor preprocessor(topCalib, unified.rois, std::nullopt);
-
-    // 5. FSM — built from YAML params, same factory as real app
-    auto fsm = SH3DS::FSM::HuntProfiles::CreateXYStarterSR(unified.fsmParams);
-    ASSERT_NE(fsm, nullptr);
-
-    // 6. Per-frame loop (mirrors Orchestrator::MainLoopTick)
-    std::vector<std::string> stateLog;
-    std::string lastState = fsm->GetCurrentState();
-
-    while (true)
-    {
-        auto frame = frameSource->Grab();
-        if (!frame.has_value())
-        {
-            break;
-        }
-
-        screenDetector->ApplyTo(preprocessor, frame->image);
-
-        auto dualResult = preprocessor.ProcessDualScreen(frame->image);
-        if (!dualResult.has_value())
-        {
-            // Screen not yet detected — keep last known state
-            stateLog.push_back(lastState);
-            continue;
-        }
-
-        // Apply color correction to the full warped top image before ROI extraction so that
-        // Gray World WB has the complete scene to compute balanced channel gains.
-        // Bottom screen is LCD-rendered UI — WB correction is not applied there.
-        if (!dualResult->warpedTop.empty())
-        {
-            dualResult->warpedTop = SH3DS::Vision::ImproveFrameColors(dualResult->warpedTop);
-            preprocessor.ReextractRois(*dualResult);
-        }
-
-        fsm->Update(dualResult->topRois, dualResult->bottomRois);
-        lastState = fsm->GetCurrentState();
-        stateLog.push_back(lastState);
-    }
-
-    frameSource->Close();
-
+    auto stateLog = RunPipeline(imagesPath, huntCfgPath);
     ASSERT_GE(stateLog.size(), 590u) << "Expected at least 590 frames; got " << stateLog.size();
 
     // Safe midpoint assertions — well inside each segment to avoid boundary sensitivity.
@@ -100,7 +99,8 @@ TEST(XYStarterFennekinReplay, StateSequenceMatchesExpected)
     // | game_menu        | 456–471           | 464          |
     // | party_menu       | 472–490           | 482          |
     // | pokemon_summary  | 491–511           | 502          |
-    // | load_game (loop) | 512–604           | 560          |
+    // | resetting        | 512–599           | 555          |
+    // | load_game (loop) | 600–604           | 602          |
     //
     EXPECT_EQ(stateLog[15], "load_game") << "Frame 15: expected load_game";
     EXPECT_EQ(stateLog[42], "game_start") << "Frame 42: expected game_start";
@@ -109,6 +109,55 @@ TEST(XYStarterFennekinReplay, StateSequenceMatchesExpected)
     EXPECT_EQ(stateLog[350], "cutscene_part_2") << "Frame 350: expected cutscene_part_2";
     EXPECT_EQ(stateLog[464], "game_menu") << "Frame 464: expected game_menu";
     EXPECT_EQ(stateLog[481], "party_menu") << "Frame 481: expected party_menu";
-    EXPECT_EQ(stateLog[534], "pokemon_summary") << "Frame 534: expected pokemon_summary";
-    EXPECT_EQ(stateLog[590], "load_game") << "Frame 590: expected load_game (loop)";
+    EXPECT_EQ(stateLog[508], "pokemon_summary") << "Frame 508: expected pokemon_summary";
+    EXPECT_EQ(stateLog[555], "resetting") << "Frame 555: expected resetting";
+    EXPECT_EQ(stateLog[602], "load_game") << "Frame 602: expected load_game (loop)";
+}
+
+/// Integration test: runs the real pipeline against live camera footage (debug_session.mp4
+/// extracted to video_replays/fennekin_live/images/).
+///
+/// This dataset exercises the camera-specific challenges absent in the video replay:
+/// MJPEG compression artifacts, JPEG blocking, auto-exposure drift, and physical
+/// button presses visible in frame. Use this test to catch regressions on real data.
+///
+/// Frame boundaries were identified manually. Update the table below whenever the
+/// live recording is replaced.
+TEST(XYStarterFennekinLive, StateSequenceMatchesExpected)
+{
+    const std::filesystem::path kRepo = SH3DS_REPO_ROOT;
+    const auto imagesPath = kRepo / "video_replays/fennekin_live/images";
+    const auto huntCfgPath = kRepo / "config/hunts/xy_starter_sr_fennekin.yaml";
+
+    if (!std::filesystem::exists(imagesPath) || std::filesystem::is_empty(imagesPath))
+    {
+        GTEST_SKIP() << "Live frames not found at " << imagesPath << " — skipping live camera test.";
+    }
+
+    auto stateLog = RunPipeline(imagesPath, huntCfgPath);
+    ASSERT_FALSE(stateLog.empty()) << "Pipeline produced no frames";
+
+    // | Segment          | User-given frames | Sample frame |
+    // |------------------|-------------------|--------------|
+    // | load_game        | 0–57              | 20           |
+    // | game_start       | 58–109            | 71           |
+    // | cutscene_part_1  | 110–378           | 246          |
+    // | starter_pick     | 379–469           | 399          |
+    // | cutscene_part_2  | 470–832           | 807          |
+    // | game_menu        | 833–866           | 837          |
+    // | party_menu       | 867–909           | 882          |
+    // | pokemon_summary  | 910–956           | 924          |
+    // | resetting        | 957–1103          | 1000         |
+    // | load_game (loop) | 1104–1189         | 1173         |
+    //
+    EXPECT_EQ(stateLog[20], "load_game") << "Frame 20: expected load_game";
+    EXPECT_EQ(stateLog[71], "game_start") << "Frame 71: expected game_start";
+    EXPECT_EQ(stateLog[246], "cutscene_part_1") << "Frame 246: expected cutscene_part_1";
+    EXPECT_EQ(stateLog[399], "starter_pick") << "Frame 399: expected starter_pick";
+    EXPECT_EQ(stateLog[807], "cutscene_part_2") << "Frame 807: expected cutscene_part_2";
+    EXPECT_EQ(stateLog[837], "game_menu") << "Frame 837: expected game_menu";
+    EXPECT_EQ(stateLog[882], "party_menu") << "Frame 882: expected party_menu";
+    EXPECT_EQ(stateLog[924], "pokemon_summary") << "Frame 924: expected pokemon_summary";
+    EXPECT_EQ(stateLog[1000], "resetting") << "Frame 1000: expected resetting";
+    EXPECT_EQ(stateLog[1173], "load_game") << "Frame 1173: expected load_game (loop)";
 }

--- a/tests/unit/TestHuntProfiles.cpp
+++ b/tests/unit/TestHuntProfiles.cpp
@@ -29,7 +29,8 @@ namespace
                  "cutscene_part_2",
                  "game_menu",
                  "party_menu",
-                 "pokemon_summary" })
+                 "pokemon_summary",
+                 "resetting" })
         {
             params.stateParams[id] = defaultSp;
         }
@@ -94,6 +95,23 @@ TEST(HuntProfiles, CreateXYStarterSRThrowsForRemovedStates)
     catch (const std::runtime_error &e)
     {
         EXPECT_NE(std::string(e.what()).find("game_menu"), std::string::npos)
+            << "Error message should name the missing state; got: " << e.what();
+    }
+}
+
+TEST(HuntProfiles, CreateXYStarterSRThrowsForMissingResettingState)
+{
+    auto params = MakeCompleteParams();
+    params.stateParams.erase("resetting");
+
+    try
+    {
+        SH3DS::FSM::HuntProfiles::CreateXYStarterSR(params);
+        FAIL() << "Expected std::runtime_error for missing resetting state";
+    }
+    catch (const std::runtime_error &e)
+    {
+        EXPECT_NE(std::string(e.what()).find("resetting"), std::string::npos)
             << "Error message should name the missing state; got: " << e.what();
     }
 }

--- a/tests/unit/TestIntensityEventDetector.cpp
+++ b/tests/unit/TestIntensityEventDetector.cpp
@@ -118,7 +118,7 @@ TEST(IntensityEventDetector, CustomConfigDropThreshold)
     cfg.dropThreshold = 0.10; // Only drop if below 10% of vMax
     SH3DS::Vision::IntensityEventDetector det(cfg);
     det.Update(1.0, 0);
-    // At 15% of vMax — with default 0.40 this would DROP, but with 0.10 it should not
+    // At 15% of vMax — with default 0.30 this would DROP, but with 0.10 it should not
     det.Update(0.15, 1);
     EXPECT_FALSE(det.IsBlack());
     EXPECT_TRUE(det.GetEvents().empty());

--- a/tests/unit/TestIntensityEventDetector.cpp
+++ b/tests/unit/TestIntensityEventDetector.cpp
@@ -27,7 +27,7 @@ TEST(IntensityEventDetector, DropEventWhenValueFallsBelowThreshold)
     SH3DS::Vision::IntensityEventDetector det;
     // Establish a vMax baseline
     det.Update(1.0, 0);
-    // Value drops below 40% of vMax (1.0) -> should trigger DROP
+    // Value drops below 30% of vMax (1.0) -> should trigger DROP
     bool isBlack = det.Update(0.10, 1);
     EXPECT_TRUE(isBlack);
     EXPECT_TRUE(det.IsBlack());

--- a/tests/unit/TestMjpegFrameSource.cpp
+++ b/tests/unit/TestMjpegFrameSource.cpp
@@ -1,6 +1,5 @@
 #include "Capture/FrameSeeker.h"
 #include "Capture/MjpegFrameSource.h"
-
 #include "Core/Config.h"
 
 #include <opencv2/core.hpp>

--- a/tests/unit/TestMjpegFrameSource.cpp
+++ b/tests/unit/TestMjpegFrameSource.cpp
@@ -141,3 +141,24 @@ TEST_F(MjpegFrameSourceTest, DoesNotImplementFrameSeeker)
     SH3DS::Capture::FrameSeeker *seeker = dynamic_cast<SH3DS::Capture::FrameSeeker *>(&source);
     EXPECT_EQ(seeker, nullptr);
 }
+
+TEST_F(MjpegFrameSourceTest, ReopenResetsSequenceNumberAndProducesFrames)
+{
+    SH3DS::Capture::MjpegFrameSource source(MakeConfig(videoPath.string()));
+    ASSERT_TRUE(source.Open());
+
+    auto firstFrame = source.Grab();
+    ASSERT_TRUE(firstFrame.has_value());
+    EXPECT_EQ(firstFrame->metadata.sequenceNumber, 0u);
+
+    source.Close();
+    EXPECT_FALSE(source.IsOpen());
+
+    ASSERT_TRUE(source.Open());
+    EXPECT_TRUE(source.IsOpen());
+
+    auto frameAfterReopen = source.Grab();
+    ASSERT_TRUE(frameAfterReopen.has_value());
+    EXPECT_EQ(frameAfterReopen->metadata.sequenceNumber, 0u);
+    EXPECT_FALSE(frameAfterReopen->image.empty());
+}

--- a/tools/analyze_frames.py
+++ b/tools/analyze_frames.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""
+Analyze HSV metrics for each frame in a replay images folder.
+
+For every frame:
+  - Detects the 3DS screen region via Otsu threshold + contour bounding box
+  - Splits the detected region into top-screen (upper) and bottom-screen (lower) halves
+  - Computes a rich set of HSV statistics on the full frame, top half, and bottom half
+
+Output: CSV file + printed summary for a configurable frame range.
+
+Usage:
+    python tools/analyze_frames.py <images_dir> [output.csv] [--range 490 620]
+
+Example:
+    python tools/analyze_frames.py video_replays/fennekin_normal/images/ metrics.csv --range 490 620
+"""
+
+import cv2
+import numpy as np
+import csv
+import sys
+import argparse
+from pathlib import Path
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Screen detection
+# ---------------------------------------------------------------------------
+
+
+def find_screen_bbox(gray: np.ndarray) -> Optional[tuple[int, int, int, int]]:
+    """
+    Detect the bounding box of the largest bright region (the 3DS screen area).
+    Returns (x, y, w, h) or None if nothing suitable is found.
+    """
+    _, thresh = cv2.threshold(gray, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)
+
+    kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (7, 7))
+    thresh = cv2.morphologyEx(thresh, cv2.MORPH_CLOSE, kernel)
+    thresh = cv2.morphologyEx(thresh, cv2.MORPH_OPEN, kernel)
+
+    contours, _ = cv2.findContours(thresh, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    if not contours:
+        return None
+
+    frame_area = gray.shape[0] * gray.shape[1]
+    largest = max(contours, key=cv2.contourArea)
+    if cv2.contourArea(largest) < 0.05 * frame_area:
+        return None
+
+    return cv2.boundingRect(largest)
+
+
+# ---------------------------------------------------------------------------
+# Metric extraction
+# ---------------------------------------------------------------------------
+
+
+def hsv_metrics(bgr: np.ndarray, prefix: str) -> dict:
+    """Compute HSV statistics for a BGR region and return them with a key prefix."""
+    if bgr is None or bgr.size == 0:
+        return {}
+
+    hsv = cv2.cvtColor(bgr, cv2.COLOR_BGR2HSV)
+    s = hsv[:, :, 1].astype(np.float32)
+    v = hsv[:, :, 2].astype(np.float32)
+    total = float(v.size)
+
+    def ratio(mask) -> float:
+        return float(np.count_nonzero(mask)) / total
+
+    return {
+        f"{prefix}_avg_v": float(np.mean(v) / 255.0),
+        f"{prefix}_std_v": float(np.std(v) / 255.0),
+        f"{prefix}_avg_s": float(np.mean(s) / 255.0),
+        # Dark pixel thresholds (V out of 255)
+        f"{prefix}_v_lt_20": ratio(v < 20),
+        f"{prefix}_v_lt_30": ratio(v < 30),
+        f"{prefix}_v_lt_50": ratio(v < 50),
+        # Bright pixel thresholds
+        f"{prefix}_v_gt_150": ratio(v > 150),
+        f"{prefix}_v_gt_180": ratio(v > 180),
+        f"{prefix}_v_gt_200": ratio(v > 200),
+        f"{prefix}_v_gt_220": ratio(v > 220),
+        # White-ish: bright AND low saturation
+        f"{prefix}_white_s40": ratio((s < 40) & (v > 180)),
+        f"{prefix}_white_s60": ratio((s < 60) & (v > 180)),
+        f"{prefix}_white_s80": ratio((s < 80) & (v > 160)),
+        # Colorful: high saturation
+        f"{prefix}_colorful": ratio(s > 80),
+    }
+
+
+def process_frame(path: Path) -> dict:
+    """Load one frame and return all metrics."""
+    img = cv2.imread(str(path))
+    if img is None:
+        return {}
+
+    gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+    bbox = find_screen_bbox(gray)
+
+    if bbox is not None:
+        x, y, w, h = bbox
+        screen = img[y : y + h, x : x + w]
+    else:
+        screen = img  # fallback: use whole frame
+
+    mid = screen.shape[0] // 2
+    top_region = screen[:mid, :]
+    bot_region = screen[mid:, :]
+
+    result: dict = {"has_bbox": int(bbox is not None)}
+    result.update(hsv_metrics(screen, "full"))
+    result.update(hsv_metrics(top_region, "top"))
+    result.update(hsv_metrics(bot_region, "bot"))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("images_dir", help="Path to folder with frame images")
+    parser.add_argument(
+        "output_csv",
+        nargs="?",
+        help="Output CSV path (default: <images_dir>/../metrics.csv)",
+    )
+    parser.add_argument(
+        "--range",
+        nargs=2,
+        type=int,
+        metavar=("FROM", "TO"),
+        help="Print summary only for this 0-based frame range (e.g. --range 490 620)",
+    )
+    args = parser.parse_args()
+
+    images_dir = Path(args.images_dir)
+    output_csv = (
+        Path(args.output_csv) if args.output_csv else images_dir.parent / "metrics.csv"
+    )
+
+    if not images_dir.exists():
+        print(f"Error: {images_dir} does not exist", file=sys.stderr)
+        sys.exit(1)
+
+    exts = {".jpg", ".jpeg", ".png", ".bmp"}
+    img_files = sorted(
+        [f for f in images_dir.iterdir() if f.suffix.lower() in exts],
+        key=lambda p: p.stem,
+    )
+
+    if not img_files:
+        print(f"No images found in {images_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Processing {len(img_files)} frames from {images_dir} ...")
+
+    rows = []
+    for idx, path in enumerate(img_files):
+        metrics = process_frame(path)
+        metrics["frame_idx"] = idx
+        metrics["filename"] = path.name
+        rows.append(metrics)
+        if idx % 100 == 0:
+            print(f"  {idx}/{len(img_files)}")
+
+    if not rows:
+        print("No frames processed.", file=sys.stderr)
+        sys.exit(1)
+
+    # Write CSV
+    fixed_cols = ["frame_idx", "filename", "has_bbox"]
+    metric_cols = sorted(k for k in rows[0] if k not in fixed_cols)
+    fieldnames = fixed_cols + metric_cols
+
+    with open(output_csv, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({k: row.get(k, "") for k in fieldnames})
+
+    print(f"\nCSV written to: {output_csv}")
+
+    # Printed summary for the interesting range
+    lo, hi = (args.range[0], args.range[1]) if args.range else (0, len(rows))
+
+    print()
+    header = (
+        f"{'fr':>5}  "
+        f"{'top_avgV':>9}  {'top_v<30':>9}  {'top_v>180':>9}  "
+        f"{'bot_avgV':>9}  {'bot_v>180':>9}  {'bot_wht_s60':>11}  {'bot_v>220':>9}"
+    )
+    print(header)
+    print("-" * len(header))
+
+    for row in rows:
+        idx = row["frame_idx"]
+        if lo <= idx <= hi:
+            print(
+                f"{idx:>5}  "
+                f"{row.get('top_avg_v', 0):>9.3f}  "
+                f"{row.get('top_v_lt_30', 0):>9.3f}  "
+                f"{row.get('top_v_gt_180', 0):>9.3f}  "
+                f"{row.get('bot_avg_v', 0):>9.3f}  "
+                f"{row.get('bot_v_gt_180', 0):>9.3f}  "
+                f"{row.get('bot_white_s60', 0):>11.3f}  "
+                f"{row.get('bot_v_gt_220', 0):>9.3f}"
+            )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `resetting` state between `pokemon_summary` and `load_game` to correctly model the soft reset blackout
- `resetting` detects dark top screen (V<50, ≥30% pixels) via `color_histogram`
- `load_game` now detects white bottom screen (save file) instead of `intensity_event`, preventing premature transition on screen appearance
- `IntensityEventDetector` drop threshold lowered 0.40 → 0.30 for improved sensitivity
- Adds `XYStarterFennekinLive` integration test with full frame boundary assertions verified against live camera footage

## Test plan

- [x] `ctest --preset ninja-release -R XYStarterFennekin` — both replay and live tests pass